### PR TITLE
feat: change name to recoil command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Protectorb
+# Recoil Command
 
 [https://proctectorb.vercel.app/](https://proctectorb.vercel.app/)
-Protectorb was inspired by Missile Command, an Atari game released in 1980.
+Recoil Command was inspired by Missile Command, an Atari game released in 1980.
 
-Protectorb sees users firing blue orbs at incoming red orbs in order to defend their blue line. When the line is hit by the incoming red orbs the players loses points. Though if the player hits the red orbs they will gain points and destroy both blue and red orb. Though keep track of your yellow power bar! Without it you can't shoot.
+Recoil Command sees users firing their missiles at incoming missiles in order to defend their blue base. When the line is hit by the incoming missiles the players loses points. Though if the player destroys the missiles they will gain points and destroy the incoming missile. Though keep track of your yellow power bar! Without it you can't shoot.
 
 ## Developing locally
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "protectorb",
+  "name": "recoil-command",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/src/components/EnemyLevel.tsx
+++ b/src/components/EnemyLevel.tsx
@@ -9,7 +9,7 @@ function EnemyLevel() {
     <div
       style={{
         position: "absolute",
-        top: 70,
+        top: 150,
         right: 0,
         zIndex: 10,
         fontSize: "3rem",

--- a/src/components/Explosion.tsx
+++ b/src/components/Explosion.tsx
@@ -11,7 +11,7 @@ function Explosion(props: { itemKey: number }) {
   const size = getExplosionSize(explosion.timer);
   return (
     <>
-      {explosion.timer <= 60 && (
+      {explosion.timer <= 30 && (
         <div
           style={{
             position: "absolute",

--- a/src/components/ItemsRenderer.tsx
+++ b/src/components/ItemsRenderer.tsx
@@ -6,12 +6,13 @@ import DefenceRange from "./DefenceRange";
 import DefenceBar from "./DefenceBar";
 import PointsTally from "./PointsTally";
 import EnemyLevel from "./EnemyLevel";
+import PowerBar from "./PowerBar";
 
 function ItemsRenderer() {
   return (
     <>
       <EnemyShooter />
-      {/* <PowerBar /> */}
+      <PowerBar />
       <DefenceBar />
       <PointsTally />
       <EnemyLevel />

--- a/src/components/PointsTally.tsx
+++ b/src/components/PointsTally.tsx
@@ -9,7 +9,7 @@ function PointsTally() {
     <div
       style={{
         position: "absolute",
-        top: 30,
+        top: 100,
         right: 0,
         zIndex: 10,
         fontSize: "3rem",

--- a/src/components/PowerBar.tsx
+++ b/src/components/PowerBar.tsx
@@ -9,7 +9,7 @@ function PowerBar() {
     <div
       style={{
         position: "absolute",
-        top: 30,
+        top: 70,
         left: 0,
         height: 30,
         zIndex: 10,

--- a/src/components/PreGame.tsx
+++ b/src/components/PreGame.tsx
@@ -29,10 +29,19 @@ function PreGame(props: PreGameProps) {
         <p>A missile command tribute.</p>
         <p>Destroy the missiles before they hit your blue base.</p>
         <p>
-          When a missile hits your defender line you will permanently lose
-          defence points from your blue defender bar (top right).
+          When a missile hits your blue base you will permanently lose defence
+          points from your blue defender bar (top right).
         </p>
         <p>If your defender bar runs out, game over.</p>
+        <p>
+          Press near the missile to shoot them down. Every missile you shoot
+          will subtract from your power bar. If your power bar runs out you
+          can't shoot.
+        </p>
+        <p>
+          Your power bar goes up when you destroy a missile, and a little bit
+          over time.
+        </p>
         <button onClick={props.onStart}>Start Game</button>
       </div>
     </div>

--- a/src/helpers/atom.utils.ts
+++ b/src/helpers/atom.utils.ts
@@ -51,7 +51,7 @@ function hasHitTarget(a: shotItem) {
 // checks if enemyShot has collided with explosion
 function hasCollided(a: enemyItem, b: explosionItem) {
   // Delay before explosion is 'active'
-  if (b.timer > 65) {
+  if (b.timer > 30) {
     return false;
   }
   const diameter = getExplosionSize(b.timer) / 2;

--- a/src/helpers/window.utils.ts
+++ b/src/helpers/window.utils.ts
@@ -2,4 +2,10 @@ export const getWidth = () => document.documentElement.clientWidth;
 
 export const getHeight = () => document.documentElement.clientHeight;
 
-export const getExplosionSize = (timer: number) => 30 + Math.abs(60 - timer);
+export const getExplosionBase = () =>
+  0.3 * (document.documentElement.clientWidth / 19.2);
+
+// Get explosion size based on time left
+// Means explosions grow slightly over time
+export const getExplosionSize = (timer: number) =>
+  getExplosionBase() + Math.abs(30 - timer);

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -89,9 +89,10 @@ export const updateItemsPositions = selector({
         // remove player shot
         set(removeActiveItem, newItem);
         // limit power to 100
-        set(powerBar, (val) => getNumberInRange(val + 10, 0, 100));
+        set(powerBar, (val) => getNumberInRange(val + 2, 0, 100));
       }
-      // If enemy shot collides with defence, adjust defence
+      // If enemy shot collides with defence
+      // Remove item
       else if (
         newItem.type === "ITEM" &&
         defenceCollisions.get(`${newItem.type}_${newItem.index}`) !== undefined
@@ -99,6 +100,7 @@ export const updateItemsPositions = selector({
         set(removeActiveItem, newItem);
       }
       // If enemy shot has hit explosion
+      // Remove item, add explosion, and increment points
       else if (
         newItem.type === "ITEM" &&
         missileCollisions.get(`${newItem.type}_${newItem.index}`) !== undefined
@@ -207,7 +209,7 @@ export const setNextShot = selector({
       type: "SHOT",
     } as shotItem);
     set(activeItems, (items) => [...items, { index: nextShot, type: "SHOT" }]);
-    // set(powerBar, (val) => getNumberInRange(val - 5, 0, 100));
+    set(powerBar, (val) => getNumberInRange(val - 5, 0, 100));
     set(lastShot, nextShot);
   },
 });
@@ -242,7 +244,7 @@ export const setExplosion = selector({
         index: newExplosion,
         x: item.x,
         y: item.y,
-        timer: 70,
+        timer: 40,
         type: "EXPLOSION",
       })
     );


### PR DESCRIPTION
Updates the projects name to Recoil Command. As well as game tweaks to make it work better on mobile, including smaller explosions depending on screen width, and adding back the power bar so players cannot simply make a 'wall of fire' to win indefinitely.