### PR TITLE
feat: prevent explosion when power is too low

### DIFF
--- a/src/components/BallShooter.tsx
+++ b/src/components/BallShooter.tsx
@@ -1,12 +1,10 @@
 import React, { useRef, useState } from "react";
 import { useSetRecoilState } from "recoil";
-import { setNextShot, getHasLost, setExplosion } from "../state/selectors";
+import { setNextShot, getHasLost } from "../state/selectors";
 import { useRecoilValue } from "recoil";
-import { explosionItem } from "../types/atom.types";
 
 function BallShooter(props: { debugMode?: boolean }) {
   const setShot = useSetRecoilState(setNextShot);
-  const setMissileExplosion = useSetRecoilState(setExplosion);
   const shooterRef = useRef<HTMLDivElement | null>(null);
   const hasLost = useRecoilValue(getHasLost);
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
@@ -53,10 +51,6 @@ function BallShooter(props: { debugMode?: boolean }) {
         x: mousePosition.x,
         y: mousePosition.y,
       },
-    });
-    setMissileExplosion({
-      x: mousePosition.x,
-      y: mousePosition.y,
     });
   }
 

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -89,7 +89,7 @@ export const updateItemsPositions = selector({
         // remove player shot
         set(removeActiveItem, newItem);
         // limit power to 100
-        set(powerBar, (val) => getNumberInRange(val + 2, 0, 100));
+        set(powerBar, (val) => getNumberInRange(val + 2.5, 0, 100));
       }
       // If enemy shot collides with defence
       // Remove item
@@ -110,7 +110,7 @@ export const updateItemsPositions = selector({
         set(setExplosion, newItem);
         set(points, (val) => val + 1);
       } else {
-        set(powerBar, (val) => getNumberInRange(val + 0.001, 0, 100));
+        set(powerBar, (val) => getNumberInRange(val + 0.002, 0, 100));
         switch (newItem.type) {
           case "ITEM":
             set(itemFamily(newItem.index), newItem as enemyItem);
@@ -203,6 +203,7 @@ export const setNextShot = selector({
       return;
     }
     const nextShot = get(getNextShotIndex);
+    set(setExplosion, { ...position.target });
     set(shotFamily(nextShot), {
       ...position,
       index: nextShot,
@@ -232,7 +233,11 @@ export const setEnemyShot = selector({
 export const setExplosion = selector({
   key: "setNextExplosion",
   get: () => {},
-  set: ({ set }, item: any) => {
+  set: ({ get, set }, item: any) => {
+    const power = get(powerBar);
+    if (power < 5) {
+      return;
+    }
     let newExplosion = 0;
     set(lastExplosion, (num) => {
       newExplosion = num + 1;


### PR DESCRIPTION
The explosion wasn't being limited to the power bar, added it in after the shot calculations to share the limitations.
Tweaked the power given when destroying a missile and upped the passive power gain.