### PR TITLE
feat: add play again button

### DIFF
--- a/src/components/DefenceBar.tsx
+++ b/src/components/DefenceBar.tsx
@@ -14,7 +14,6 @@ function DefenceBar() {
         height: 30,
         zIndex: 10,
         width: 300,
-        border: "1px solid black",
       }}
     >
       <div

--- a/src/components/EnemyShooter.tsx
+++ b/src/components/EnemyShooter.tsx
@@ -10,29 +10,28 @@ function EnemyShooter() {
   const hasLost = useRecoilValue(getHasLost);
 
   useEffect(() => {
+    function handleEnemyShoot() {
+      if (hasLost) {
+        return;
+      }
+      const random = Math.random();
+      if (random < level) {
+        const width = getWidth();
+        setShot({
+          y: 0,
+          x: Math.floor(Math.random() * width),
+          // Larger the screen width the larger xIncrement can be
+          xIncrement: Math.random() * (0.1 * (width / 192)),
+          yIncrement: -Math.abs(Math.random()),
+          xCount: 0,
+          yCount: 0,
+          veerLeft: Math.random() > 0.5,
+        });
+      }
+    }
     const interval = setInterval(handleEnemyShoot, 10);
     return () => clearInterval(interval);
-  }, [level, hasLost]);
-
-  function handleEnemyShoot() {
-    if (hasLost) {
-      return;
-    }
-    const random = Math.random();
-    if (random < level) {
-      const width = getWidth();
-      setShot({
-        y: 0,
-        x: Math.floor(Math.random() * width),
-        // Larger the screen width the larger xIncrement can be
-        xIncrement: Math.random() * (0.1 * (width / 192)),
-        yIncrement: -Math.abs(Math.random()),
-        xCount: 0,
-        yCount: 0,
-        veerLeft: Math.random() > 0.5,
-      });
-    }
-  }
+  }, [level, hasLost, setShot]);
 
   return <></>;
 }

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -16,7 +16,7 @@ function GameBoard() {
     return () => {
       clearInterval(interval);
     };
-  }, [intervalMs, hasLost]);
+  }, [intervalMs, hasLost, render]);
 
   return (
     <>

--- a/src/components/GameOver.tsx
+++ b/src/components/GameOver.tsx
@@ -6,6 +6,9 @@ import { getReadableLevel } from "../state/selectors";
 function GameOver() {
   const pointTally = useRecoilValue(points);
   const level = useRecoilValue(getReadableLevel);
+  function reload() {
+    window.location.reload();
+  }
   return (
     <div
       style={{
@@ -19,10 +22,10 @@ function GameOver() {
       <div
         style={{
           width: 200,
-          height: 150,
           textAlign: "center",
           backgroundColor: "white",
           margin: "0 auto",
+          paddingBottom: "1rem",
           borderRadius: 15,
           zIndex: 15,
         }}
@@ -30,6 +33,7 @@ function GameOver() {
         <h2>You did your best!</h2>
         <p>Your points total was: {pointTally}</p>
         <p>You got up to level: {level}</p>
+        <button onClick={reload}>Play Again</button>
       </div>
     </div>
   );

--- a/src/components/PowerBar.tsx
+++ b/src/components/PowerBar.tsx
@@ -14,7 +14,6 @@ function PowerBar() {
         height: 30,
         zIndex: 10,
         width: 300,
-        border: "1px solid black",
       }}
     >
       <div

--- a/src/helpers/hooks.ts
+++ b/src/helpers/hooks.ts
@@ -1,7 +1,7 @@
 import { useSetRecoilState } from "recoil";
 import { getWidth, getHeight } from "./window.utils";
 import { useEffect } from "react";
-import { item, movingItems } from "../types/atom.types";
+import { movingItems } from "../types/atom.types";
 import { removeActiveItem } from "../state/selectors";
 
 export function useIsActive(currentItem: movingItems) {
@@ -37,5 +37,5 @@ export function useIsActive(currentItem: movingItems) {
         });
       }
     }
-  }, [currentItem]);
+  }, [currentItem, removeItemFromActive]);
 }

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -21,7 +21,6 @@ import {
   isSameItemOrTrailFor,
 } from "../helpers/atom.utils";
 import {
-  items,
   itemTrail,
   shotItem,
   enemyItem,
@@ -80,7 +79,7 @@ export const updateItemsPositions = selector({
       isDefenceHit,
     } = determineCollisions(items);
 
-    newStates.forEach((newItem: items) => {
+    newStates.forEach((newItem) => {
       // If shot reaches target, adjust points/power and removes active item
       // sets explosion
       if (


### PR DESCRIPTION
Adds 'Play again' button in game over screen which simply reloads the page. Starting again without reload would not be advisable as Recoil doesn't delete atoms, so there would be a memory leak associated with long plays.

Fixed some rules of hooks warning.